### PR TITLE
C: 1 - Created the MVP framework; presenter and view interface, base activity and fragment, etc. Closes #12

### DIFF
--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/presenter/BasePresenter.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/presenter/BasePresenter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Vandolf Estrellado
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vestrel00.daggerbutterknifemvp.ui.common.presenter;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+
+import com.vestrel00.daggerbutterknifemvp.ui.common.view.MVPView;
+
+/**
+ * Abstract {@link Presenter} for all presenters to extend.
+ *
+ * @param <T> the type of the {@link MVPView}.
+ */
+public abstract class BasePresenter<T extends MVPView> implements Presenter {
+
+    protected final T view;
+
+    protected BasePresenter(T view) {
+        this.view = view;
+    }
+
+    @Override
+    public void onStart(@Nullable Bundle savedInstanceState) {
+    }
+
+    @Override
+    public void onResume() {
+    }
+
+    @Override
+    public void onPause() {
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+    }
+
+    @Override
+    public void onEnd() {
+    }
+}

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/presenter/Presenter.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/presenter/Presenter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Vandolf Estrellado
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vestrel00.daggerbutterknifemvp.ui.common.presenter;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+
+/**
+ * A presenter that defines its own lifecycle methods.
+ */
+public interface Presenter {
+
+    /**
+     * Starts the presentation. This should be called in the view's (Activity or Fragment)
+     * onCreate() or onViewStatedRestored() method respectively.
+     *
+     * @param savedInstanceState the saved instance state that contains state saved in
+     *                           {@link #onSaveInstanceState(Bundle)}
+     */
+    void onStart(@Nullable Bundle savedInstanceState);
+
+    /**
+     * Resumes the presentation. This should be called in the view's (Activity or Fragment)
+     * onResume() method.
+     */
+    void onResume();
+
+    /**
+     * Pauses the presentation. This should be called in the view's Activity or Fragment)
+     * onPause() method.
+     */
+    void onPause();
+
+    /**
+     * Save the state of the presentation (if any). This should be called in the view's
+     * (Activity or Fragment) onSaveInstanceState().
+     *
+     * @param outState the out state to save instance state
+     */
+    void onSaveInstanceState(Bundle outState);
+
+    /**
+     * Ends the presentation. This should be called in the view's (Activity or Fragment)
+     * onDestroy() or onDestroyView() method respectively.
+     */
+    void onEnd();
+}

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/BaseChildFragmentModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/BaseChildFragmentModule.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Vandolf Estrellado
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vestrel00.daggerbutterknifemvp.ui.common.view;
+
+import android.app.Fragment;
+
+import dagger.Module;
+
+/**
+ * Provides base fragment dependencies. This must be included in all child fragment modules, which
+ * must provide a concrete implementation of the child {@link Fragment} and named
+ * {@link #CHILD_FRAGMENT}.
+ * <p>
+ * Note that a different {@link javax.inject.Named} for the {@link Fragment} is required in order to
+ * remove any ambiguity about which fragment is being provided in a child fragment. For example,
+ * we have parent fragment P and child fragment C. Parent fragment P will provide the Fragment
+ * reference using the {@link BaseFragmentModule#FRAGMENT} name. Child fragment C will provide the
+ * Fragment reference using the {@link #CHILD_FRAGMENT} name.
+ * <p>
+ * If the parent and child fragments are not uniquely named, then the child fragment and its
+ * dependencies will not know which Fragment is provided to it. It could be the parent fragment
+ * or the child fragment. Hence the ambiguity, which causes a compile error of
+ * "android.app.Fragment is bound multiple times".
+ */
+@Module
+public abstract class BaseChildFragmentModule {
+
+    /**
+     * See class documentation regarding the need for this name.
+     */
+    public static final String CHILD_FRAGMENT = "BaseChildFragmentModule.childFragment";
+}

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/BaseFragment.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/BaseFragment.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017 Vandolf Estrellado
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vestrel00.daggerbutterknifemvp.ui.common.view;
+
+import android.app.Fragment;
+import android.app.FragmentManager;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.View;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import butterknife.ButterKnife;
+import butterknife.Unbinder;
+import dagger.android.AndroidInjection;
+import dagger.android.AndroidInjector;
+import dagger.android.DispatchingAndroidInjector;
+import dagger.android.HasFragmentInjector;
+
+/**
+ * Abstract Fragment for all Fragments and child Fragments to extend. This contains some boilerplate
+ * dependency injection code and activity {@link Context}.
+ * <p>
+ * <b>DEPENDENCY INJECTION</b>
+ * We could extend {@link dagger.android.DaggerFragment} so we can get the boilerplate
+ * dagger code for free. However, we want to avoid inheritance (if possible and it is in this case)
+ * so that we have to option to inherit from something else later on if needed.
+ * <p>
+ * <b>VIEW BINDING</b>
+ * This fragment handles view bind and unbinding.
+ */
+public abstract class BaseFragment extends Fragment implements HasFragmentInjector {
+
+    @Inject
+    protected Context activityContext;
+
+    // Note that this should not be used within a child fragment.
+    @Inject
+    @Named(BaseFragmentModule.CHILD_FRAGMENT_MANAGER)
+    protected FragmentManager childFragmentManager;
+
+    @Inject
+    DispatchingAndroidInjector<Fragment> fragmentInjector;
+
+    private Unbinder viewUnbinder;
+
+    @Override
+    public void onAttach(Context context) {
+        AndroidInjection.inject(this);
+        super.onAttach(context);
+    }
+
+    @Override
+    public void onViewStateRestored(Bundle savedInstanceState) {
+        super.onViewStateRestored(savedInstanceState);
+        View view = getView();
+        if (view != null) {
+            /*
+             * Bind the views here instead of in onViewCreated so that view state changed listeners
+             * are not invoked automatically without user interaction.
+             *
+             * If we bind before this method (e.g. onViewCreated), then any checked changed
+             * listeners bound by ButterKnife will be invoked during fragment recreation.
+             *
+             * The lifecycle order is as follows (same if added via xml or java
+             * or if retain instance is true):
+             *
+             * onAttach
+             * onCreateView
+             * onActivityCreated
+             * onViewStateRestored
+             * onResume
+             */
+            viewUnbinder = ButterKnife.bind(this, getView());
+        }
+    }
+
+    @Override
+    public void onDestroyView() {
+        if (viewUnbinder != null) {
+            viewUnbinder.unbind();
+        }
+        super.onDestroyView();
+    }
+
+    @Override
+    public final AndroidInjector<Fragment> fragmentInjector() {
+        return fragmentInjector;
+    }
+
+    protected final void addChildFragment(int containerViewId, Fragment fragment) {
+        childFragmentManager.beginTransaction()
+                .add(containerViewId, fragment)
+                .commit();
+    }
+}

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/BaseFragmentModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/BaseFragmentModule.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Vandolf Estrellado
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vestrel00.daggerbutterknifemvp.ui.common.view;
+
+import android.app.Fragment;
+import android.app.FragmentManager;
+
+import com.vestrel00.daggerbutterknifemvp.inject.PerFragment;
+
+import javax.inject.Named;
+
+import dagger.Module;
+import dagger.Provides;
+
+/**
+ * Provides base fragment dependencies. This must be included in all fragment modules, which must
+ * provide a concrete implementation of {@link Fragment} and named {@link #FRAGMENT}.
+ */
+@Module
+public abstract class BaseFragmentModule {
+
+    /**
+     * See {@link BaseChildFragmentModule} class documentation regarding the need for this name.
+     */
+    public static final String FRAGMENT = "BaseFragmentModule.fragment";
+
+    static final String CHILD_FRAGMENT_MANAGER = "BaseFragmentModule.childFragmentManager";
+
+    @Provides
+    @Named(CHILD_FRAGMENT_MANAGER)
+    @PerFragment
+    static FragmentManager childFragmentManager(@Named(FRAGMENT) Fragment fragment) {
+        return fragment.getChildFragmentManager();
+    }
+}

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/BaseViewFragment.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/BaseViewFragment.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 Vandolf Estrellado
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vestrel00.daggerbutterknifemvp.ui.common.view;
+
+import android.os.Bundle;
+import android.support.annotation.CallSuper;
+
+import com.vestrel00.daggerbutterknifemvp.ui.common.presenter.Presenter;
+
+import javax.inject.Inject;
+
+/**
+ * A {@link BaseFragment} that contains and invokes {@link Presenter} lifecycle invocations.
+ *
+ * @param <T> the type of the {@link Presenter}.
+ */
+public abstract class BaseViewFragment<T extends Presenter> extends BaseFragment
+        implements MVPView {
+
+    @Inject
+    protected T presenter;
+
+    @Override
+    public void onViewStateRestored(Bundle savedInstanceState) {
+        super.onViewStateRestored(savedInstanceState);
+        // Only start the presenter when the views have been bound.
+        // See BaseFragment.onViewStateRestored
+        presenter.onStart(savedInstanceState);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        presenter.onResume();
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        presenter.onPause();
+    }
+
+    @CallSuper
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        presenter.onSaveInstanceState(outState);
+    }
+
+    @Override
+    public void onDestroyView() {
+        presenter.onEnd();
+        super.onDestroyView();
+    }
+}

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/MVPView.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/MVPView.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Vandolf Estrellado
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vestrel00.daggerbutterknifemvp.ui.common.view;
+
+/**
+ * The type of all views.
+ * <p>
+ * Note that this is not named "View" because it collides with Android's {@link android.view.View}.
+ */
+public interface MVPView {
+}


### PR DESCRIPTION
Created the MVP framework; presenter and view interface, base activity and fragment, etc.

There is a duplicate of BaseFragment, BaseFragmentModule, and BaseChildFragmentModule in the ui.common.view package that are currently unused but will be used during the migration in the upcoming PRs.