### PR TITLE
C: 3 - Refactored main activity to use MVP pattern. Closes #14

### DIFF
--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/MainActivity.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/MainActivity.java
@@ -21,6 +21,8 @@ import android.support.annotation.Nullable;
 
 import com.vestrel00.daggerbutterknifemvp.R;
 import com.vestrel00.daggerbutterknifemvp.ui.common.BaseActivity;
+import com.vestrel00.daggerbutterknifemvp.ui.main.view.MainFragment;
+import com.vestrel00.daggerbutterknifemvp.ui.main.view.MainFragmentListener;
 
 /**
  * The main activity that provides a way to navigate to all other activities.

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/MainActivityModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/MainActivityModule.java
@@ -21,6 +21,9 @@ import android.app.Activity;
 import com.vestrel00.daggerbutterknifemvp.inject.PerActivity;
 import com.vestrel00.daggerbutterknifemvp.inject.PerFragment;
 import com.vestrel00.daggerbutterknifemvp.ui.common.BaseActivityModule;
+import com.vestrel00.daggerbutterknifemvp.ui.main.view.MainFragment;
+import com.vestrel00.daggerbutterknifemvp.ui.main.view.MainFragmentListener;
+import com.vestrel00.daggerbutterknifemvp.ui.main.view.MainFragmentModule;
 
 import dagger.Binds;
 import dagger.Module;

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/view/MainFragment.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/view/MainFragment.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.vestrel00.daggerbutterknifemvp.ui.main;
+package com.vestrel00.daggerbutterknifemvp.ui.main.view;
 
 import android.os.Bundle;
 import android.support.annotation.Nullable;

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/view/MainFragmentListener.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/view/MainFragmentListener.java
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package com.vestrel00.daggerbutterknifemvp.ui.main;
+package com.vestrel00.daggerbutterknifemvp.ui.main.view;
 
 /**
  * Listener for {@link MainFragment} UI events.
  */
-interface MainFragmentListener {
+public interface MainFragmentListener {
 
     void onExample1Clicked();
 

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/view/MainFragmentModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/view/MainFragmentModule.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.vestrel00.daggerbutterknifemvp.ui.main;
+package com.vestrel00.daggerbutterknifemvp.ui.main.view;
 
 import android.app.Fragment;
 
@@ -30,7 +30,7 @@ import dagger.Module;
  * Provides main fragment dependencies.
  */
 @Module(includes = BaseFragmentModule.class)
-abstract class MainFragmentModule {
+public abstract class MainFragmentModule {
 
     /**
      * As per the contract specified in {@link BaseFragmentModule}; "This must be included in all


### PR DESCRIPTION
Refactored main activity to use MVP pattern.

The ui.main fragment classes have just been moved to the ui.main.view package. No further refactors required since the main fragment does not contain any logic to warrant implementing a view and having a presenter.