### PR TITLE
A: How to provide the Application / Application Context to Singleton dependencies. Closes #42

### DIFF
--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/App.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/App.java
@@ -42,7 +42,10 @@ public class App extends Application implements HasActivityInjector {
     @Override
     public void onCreate() {
         super.onCreate();
-        DaggerAppComponent.create().inject(this);
+        DaggerAppComponent.builder()
+                .applicationProviderModule(new ApplicationProviderModule(this))
+                .build()
+                .inject(this);
     }
 
     @Override

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/AppModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/AppModule.java
@@ -33,7 +33,10 @@ import dagger.android.ContributesAndroidInjector;
 /**
  * Provides application-wide dependencies.
  */
-@Module(includes = AndroidInjectionModule.class)
+@Module(includes = {
+        AndroidInjectionModule.class,
+        ApplicationProviderModule.class
+})
 abstract class AppModule {
 
     /**

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ApplicationProviderModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ApplicationProviderModule.java
@@ -1,0 +1,47 @@
+package com.vestrel00.daggerbutterknifemvp;
+
+import android.app.Application;
+
+import javax.inject.Singleton;
+
+import dagger.Module;
+import dagger.Provides;
+
+/**
+ * Provides a reference to the {@link Application}. The {@link Application} is not provided in the
+ * {@link AppModule} because it needs to remain abstract to maintain its abstract injector methods.
+ * <p>
+ * Providing the reference to the {@link Application} is used for providing the Application
+ * {@link android.content.Context} instead of the Activity context to {@link Singleton}
+ * dependencies. For example, a third party library like Picasso requires the Application context
+ * in order to instantiate a unique instance.
+ * <p>
+ * This is required as of Dagger 2.11 in order to provide the {@link Application} instance.
+ * <p>
+ * FIXME: Check if future versions of Dagger gets rid of the need to for this module.
+ */
+@Module
+class ApplicationProviderModule {
+
+    private final Application application;
+
+    ApplicationProviderModule(Application application) {
+        this.application = application;
+    }
+
+    /**
+     * Returns the {@link Application} type instead of {@link android.content.Context} to avoid
+     * type collision with the Activity's context. Another way to resolve the context type collision
+     * is to use different {@link javax.inject.Named} values for the Application and Activity
+     * context. However, just providing the Application type is simpler and lighter in weight.
+     *
+     * @return the {@link Application} instance
+     */
+    @Provides
+    @Singleton
+    Application application() {
+        // Does not need to be annotated with @Singleton since it returns the same instance.
+        // It is only annotated with @Singleton to honor convention.
+        return application;
+    }
+}

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/util/SingletonUtil.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/util/SingletonUtil.java
@@ -16,6 +16,8 @@
 
 package com.vestrel00.daggerbutterknifemvp.util;
 
+import android.app.Application;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -29,15 +31,18 @@ import javax.inject.Singleton;
 @Singleton
 public final class SingletonUtil {
 
+    private final Application application;
+
     @Inject
-    SingletonUtil() {
+    SingletonUtil(Application application) {
+        this.application = application;
     }
 
     /**
      * @return the result of the work done here as a string. For this example, this returns its
-     * {@link #hashCode()}.
+     * {@link #hashCode()} and the application's {@link #hashCode()}.
      */
     public String doSomething() {
-        return "SingletonUtil: " + hashCode();
+        return "SingletonUtil: " + hashCode() + ", Application: " + application.hashCode();
     }
 }


### PR DESCRIPTION
Answers #42. Note that this PR **will not be merged** as I consider it an edge case that needs to be fixed it future versions of Dagger. Currently, Dagger 2.11 does not allow the Application instance to be implicitly provided using the same method used to provide Activity and Fragment instances;

```java
abstract class AppModule {
    @Binds
    @Singleton
    abstract Application application(App app);
}
```

The above gives the following compile-time error:

```
error: [dagger.android.AndroidInjector.inject(T)] com.vestrel00.daggerbutterknifemvp.App cannot be provided without an @Inject constructor or from an @Provides-annotated method. This type supports members injection but cannot be implicitly provided.
```

The current solution (and what I consider a workaround) is to store the Application instance in a module so that it may be provided;

```java
@Module
class ApplicationProviderModule {

    private final Application application;

    ApplicationProviderModule(Application application) {
        this.application = application;
    }

    @Provides
    @Singleton
    Application application() {
        return application;
    }
}


@Module(includes = {
        AndroidInjectionModule.class,
        ApplicationProviderModule.class
})
abstract class AppModule {
    ...
}

public class App extends Application implements HasActivityInjector {
    ...
    @Override
    public void onCreate() {
        super.onCreate();
        DaggerAppComponent.builder()
                .applicationProviderModule(new ApplicationProviderModule(this))
                .build()
                .inject(this);
    }
    ...
}
```