### PR TITLE
Fixed fragment injection not occurring for Android versions 22 (Lollipop 5.1) and below. Closes #46

### DIFF
--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/BaseFragment.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/BaseFragment.java
@@ -16,9 +16,11 @@
 
 package com.vestrel00.daggerbutterknifemvp.ui.common.view;
 
+import android.app.Activity;
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.content.Context;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.IdRes;
 import android.support.annotation.Nullable;
@@ -62,9 +64,23 @@ public abstract class BaseFragment extends Fragment implements HasFragmentInject
     @Nullable
     private Unbinder viewUnbinder;
 
+    @SuppressWarnings("deprecation")
+    @Override
+    public void onAttach(Activity activity) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            // Perform injection here before M, L (API 22) and below because onAttach(Context)
+            // is not yet available at L.
+            AndroidInjection.inject(this);
+        }
+        super.onAttach(activity);
+    }
+
     @Override
     public void onAttach(Context context) {
-        AndroidInjection.inject(this);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            // Perform injection here for M (API 23) due to deprecation of onAttach(Activity).
+            AndroidInjection.inject(this);
+        }
         super.onAttach(context);
     }
 


### PR DESCRIPTION
This fixes #46 