### PR TITLE
Using the dagger.android.support lib for compatibility with AppCompatActivity and support Fragment with minSdkVersion changed from 17 to 14. Closes #48

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,7 @@ android {
         versionCode 1
         versionName '1.0.0'
 
-        minSdkVersion 17
+        minSdkVersion 14
         targetSdkVersion 26
 
         testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
@@ -37,6 +37,7 @@ dependencies {
     // However, that is a different topic.
     def daggerVersion = '2.11'
     def butterKnifeVersion = '8.7.0'
+    def supportVersion = '26.0.1'
 
     annotationProcessor "com.google.dagger:dagger-compiler:$daggerVersion"
     annotationProcessor "com.google.dagger:dagger-android-processor:$daggerVersion"
@@ -44,5 +45,7 @@ dependencies {
 
     compile "com.google.dagger:dagger:$daggerVersion"
     compile "com.google.dagger:dagger-android:$daggerVersion"
+    compile "com.google.dagger:dagger-android-support:$daggerVersion"
     compile "com.jakewharton:butterknife:$butterKnifeVersion"
+    compile "com.android.support:appcompat-v7:$supportVersion"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,10 @@
     <application
         android:name=".App"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name">
+        android:label="@string/app_name"
+        android:theme="@style/Theme.AppCompat">
+
+        <!-- Theme.AppCompat (or descendant) is required for AppCompatActivity -->
 
         <activity android:name=".ui.main.MainActivity">
             <intent-filter>

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/App.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/App.java
@@ -29,7 +29,7 @@ import dagger.android.HasActivityInjector;
  * The Android {@link Application}.
  * <p>
  * <b>DEPENDENCY INJECTION</b>
- * We could extend {@link dagger.android.DaggerApplication} so we can get the boilerplate
+ * We could extend {@link dagger.android.support.DaggerApplication} so we can get the boilerplate
  * dagger code for free. However, we want to avoid inheritance (if possible and it is in this case)
  * so that we have to option to inherit from something else later on if needed
  */

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/AppModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/AppModule.java
@@ -32,13 +32,13 @@ import javax.inject.Singleton;
 
 import dagger.Binds;
 import dagger.Module;
-import dagger.android.AndroidInjectionModule;
 import dagger.android.ContributesAndroidInjector;
+import dagger.android.support.AndroidSupportInjectionModule;
 
 /**
  * Provides application-wide dependencies.
  */
-@Module(includes = AndroidInjectionModule.class)
+@Module(includes = AndroidSupportInjectionModule.class)
 abstract class AppModule {
 
     @Binds

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/BaseActivity.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/BaseActivity.java
@@ -16,12 +16,12 @@
 
 package com.vestrel00.daggerbutterknifemvp.ui.common;
 
-import android.app.Activity;
-import android.app.Fragment;
-import android.app.FragmentManager;
 import android.os.Bundle;
 import android.support.annotation.IdRes;
 import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v7.app.AppCompatActivity;
 
 import com.vestrel00.daggerbutterknifemvp.navigation.Navigator;
 
@@ -31,17 +31,17 @@ import javax.inject.Named;
 import dagger.android.AndroidInjection;
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
-import dagger.android.HasFragmentInjector;
+import dagger.android.support.HasSupportFragmentInjector;
 
 /**
  * Abstract Activity for all Activities to extend.
  * <p>
  * <b>DEPENDENCY INJECTION</b>
- * We could extend {@link dagger.android.DaggerActivity} so we can get the boilerplate
+ * We could extend {@link dagger.android.support.DaggerAppCompatActivity} so we can get the boilerplate
  * dagger code for free. However, we want to avoid inheritance (if possible and it is in this case)
  * so that we have to option to inherit from something else later on if needed.
  */
-public abstract class BaseActivity extends Activity implements HasFragmentInjector {
+public abstract class BaseActivity extends AppCompatActivity implements HasSupportFragmentInjector {
 
     @Inject
     protected Navigator navigator;
@@ -60,7 +60,7 @@ public abstract class BaseActivity extends Activity implements HasFragmentInject
     }
 
     @Override
-    public final AndroidInjector<Fragment> fragmentInjector() {
+    public final AndroidInjector<Fragment> supportFragmentInjector() {
         return fragmentInjector;
     }
 

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/BaseActivityModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/BaseActivityModule.java
@@ -1,8 +1,9 @@
 package com.vestrel00.daggerbutterknifemvp.ui.common;
 
 import android.app.Activity;
-import android.app.FragmentManager;
 import android.content.Context;
+import android.support.v4.app.FragmentManager;
+import android.support.v7.app.AppCompatActivity;
 
 import com.vestrel00.daggerbutterknifemvp.inject.PerActivity;
 
@@ -14,7 +15,7 @@ import dagger.Provides;
 
 /**
  * Provides base activity dependencies. This must be included in all activity modules, which must
- * provide a concrete implementation of {@link Activity}.
+ * provide a concrete implementation of {@link AppCompatActivity}.
  */
 @Module
 public abstract class BaseActivityModule {
@@ -32,12 +33,16 @@ public abstract class BaseActivityModule {
      * However, having a scope annotation makes the module easier to read. We wouldn't have to look
      * at what is being provided in order to understand its scope.
      */
+    abstract Activity activity(AppCompatActivity appCompatActivity);
+
+    @Binds
+    @PerActivity
     abstract Context activityContext(Activity activity);
 
     @Provides
     @Named(ACTIVITY_FRAGMENT_MANAGER)
     @PerActivity
-    static FragmentManager activityFragmentManager(Activity activity) {
-        return activity.getFragmentManager();
+    static FragmentManager activityFragmentManager(AppCompatActivity activity) {
+        return activity.getSupportFragmentManager();
     }
 }

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/BaseFragment.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/BaseFragment.java
@@ -16,38 +16,36 @@
 
 package com.vestrel00.daggerbutterknifemvp.ui.common.view;
 
-import android.app.Activity;
-import android.app.Fragment;
-import android.app.FragmentManager;
 import android.content.Context;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.IdRes;
 import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 
 import butterknife.ButterKnife;
 import butterknife.Unbinder;
-import dagger.android.AndroidInjection;
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
-import dagger.android.HasFragmentInjector;
+import dagger.android.support.AndroidSupportInjection;
+import dagger.android.support.HasSupportFragmentInjector;
 
 /**
  * Abstract Fragment for all Fragments and child Fragments to extend. This contains some boilerplate
  * dependency injection code and activity {@link Context}.
  * <p>
  * <b>DEPENDENCY INJECTION</b>
- * We could extend {@link dagger.android.DaggerFragment} so we can get the boilerplate
+ * We could extend {@link dagger.android.support.DaggerFragment} so we can get the boilerplate
  * dagger code for free. However, we want to avoid inheritance (if possible and it is in this case)
  * so that we have to option to inherit from something else later on if needed.
  * <p>
  * <b>VIEW BINDING</b>
  * This fragment handles view bind and unbinding.
  */
-public abstract class BaseFragment extends Fragment implements HasFragmentInjector {
+public abstract class BaseFragment extends Fragment implements HasSupportFragmentInjector {
 
     @Inject
     protected Context activityContext;
@@ -63,23 +61,10 @@ public abstract class BaseFragment extends Fragment implements HasFragmentInject
     @Nullable
     private Unbinder viewUnbinder;
 
-    @SuppressWarnings("deprecation")
-    @Override
-    public void onAttach(Activity activity) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            // Perform injection here before M, L (API 22) and below because onAttach(Context)
-            // is not yet available at L.
-            AndroidInjection.inject(this);
-        }
-        super.onAttach(activity);
-    }
-
     @Override
     public void onAttach(Context context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            // Perform injection here for M (API 23) due to deprecation of onAttach(Activity).
-            AndroidInjection.inject(this);
-        }
+        // This is called even for API levels below 23.
+        AndroidSupportInjection.inject(this);
         super.onAttach(context);
     }
 
@@ -130,7 +115,7 @@ public abstract class BaseFragment extends Fragment implements HasFragmentInject
     }
 
     @Override
-    public final AndroidInjector<Fragment> fragmentInjector() {
+    public final AndroidInjector<Fragment> supportFragmentInjector() {
         return childFragmentInjector;
     }
 

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/BaseFragmentModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/BaseFragmentModule.java
@@ -16,8 +16,8 @@
 
 package com.vestrel00.daggerbutterknifemvp.ui.common.view;
 
-import android.app.Fragment;
-import android.app.FragmentManager;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
 
 import com.vestrel00.daggerbutterknifemvp.inject.PerFragment;
 

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/example_1/Example1ActivityModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/example_1/Example1ActivityModule.java
@@ -16,7 +16,7 @@
 
 package com.vestrel00.daggerbutterknifemvp.ui.example_1;
 
-import android.app.Activity;
+import android.support.v7.app.AppCompatActivity;
 
 import com.vestrel00.daggerbutterknifemvp.inject.PerActivity;
 import com.vestrel00.daggerbutterknifemvp.inject.PerFragment;
@@ -44,7 +44,7 @@ public abstract class Example1ActivityModule {
 
     /**
      * As per the contract specified in {@link BaseActivityModule}; "This must be included in all
-     * activity modules, which must rovide a concrete implementation of {@link Activity}."
+     * activity modules, which must rovide a concrete implementation of {@link AppCompatActivity}."
      * <p>
      * This provides the activity required to inject the
      * {@link BaseActivityModule#ACTIVITY_FRAGMENT_MANAGER} into the
@@ -55,5 +55,5 @@ public abstract class Example1ActivityModule {
      */
     @Binds
     @PerActivity
-    abstract Activity activity(Example1Activity example1Activity);
+    abstract AppCompatActivity appCompatActivity(Example1Activity example1Activity);
 }

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/example_1/fragment/view/Example1FragmentModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/example_1/fragment/view/Example1FragmentModule.java
@@ -16,7 +16,7 @@
 
 package com.vestrel00.daggerbutterknifemvp.ui.example_1.fragment.view;
 
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 
 import com.vestrel00.daggerbutterknifemvp.inject.PerFragment;
 import com.vestrel00.daggerbutterknifemvp.ui.common.view.BaseFragmentModule;

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/example_2/Example2ActivityModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/example_2/Example2ActivityModule.java
@@ -16,7 +16,7 @@
 
 package com.vestrel00.daggerbutterknifemvp.ui.example_2;
 
-import android.app.Activity;
+import android.support.v7.app.AppCompatActivity;
 
 import com.vestrel00.daggerbutterknifemvp.inject.PerActivity;
 import com.vestrel00.daggerbutterknifemvp.inject.PerFragment;
@@ -54,7 +54,7 @@ public abstract class Example2ActivityModule {
 
     /**
      * As per the contract specified in {@link BaseActivityModule}; "This must be included in all
-     * activity modules, which must rovide a concrete implementation of {@link Activity}."
+     * activity modules, which must rovide a concrete implementation of {@link AppCompatActivity}."
      * <p>
      * This provides the activity required to inject the
      * {@link BaseActivityModule#ACTIVITY_FRAGMENT_MANAGER} into the
@@ -65,5 +65,5 @@ public abstract class Example2ActivityModule {
      */
     @Binds
     @PerActivity
-    abstract Activity activity(Example2Activity example2Activity);
+    abstract AppCompatActivity appCompatActivity(Example2Activity example2Activity);
 }

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/example_2/fragment_a/view/Example2AFragmentModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/example_2/fragment_a/view/Example2AFragmentModule.java
@@ -16,7 +16,7 @@
 
 package com.vestrel00.daggerbutterknifemvp.ui.example_2.fragment_a.view;
 
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 
 import com.vestrel00.daggerbutterknifemvp.inject.PerFragment;
 import com.vestrel00.daggerbutterknifemvp.ui.common.view.BaseFragmentModule;

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/example_2/fragment_b/view/Example2BFragmentModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/example_2/fragment_b/view/Example2BFragmentModule.java
@@ -16,7 +16,7 @@
 
 package com.vestrel00.daggerbutterknifemvp.ui.example_2.fragment_b.view;
 
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 
 import com.vestrel00.daggerbutterknifemvp.inject.PerFragment;
 import com.vestrel00.daggerbutterknifemvp.ui.common.view.BaseFragmentModule;

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/example_3/Example3ActivityModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/example_3/Example3ActivityModule.java
@@ -16,7 +16,7 @@
 
 package com.vestrel00.daggerbutterknifemvp.ui.example_3;
 
-import android.app.Activity;
+import android.support.v7.app.AppCompatActivity;
 
 import com.vestrel00.daggerbutterknifemvp.inject.PerActivity;
 import com.vestrel00.daggerbutterknifemvp.inject.PerFragment;
@@ -44,7 +44,7 @@ public abstract class Example3ActivityModule {
 
     /**
      * As per the contract specified in {@link BaseActivityModule}; "This must be included in all
-     * activity modules, which must rovide a concrete implementation of {@link Activity}."
+     * activity modules, which must rovide a concrete implementation of {@link AppCompatActivity}."
      * <p>
      * This provides the activity required to inject the
      * {@link BaseActivityModule#ACTIVITY_FRAGMENT_MANAGER} into the
@@ -55,5 +55,5 @@ public abstract class Example3ActivityModule {
      */
     @Binds
     @PerActivity
-    abstract Activity activity(Example3Activity example3Activity);
+    abstract AppCompatActivity appCompatActivity(Example3Activity example3Activity);
 }

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/example_3/child_fragment/view/Example3ChildFragmentModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/example_3/child_fragment/view/Example3ChildFragmentModule.java
@@ -16,7 +16,7 @@
 
 package com.vestrel00.daggerbutterknifemvp.ui.example_3.child_fragment.view;
 
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 
 import com.vestrel00.daggerbutterknifemvp.inject.PerChildFragment;
 import com.vestrel00.daggerbutterknifemvp.ui.common.view.BaseChildFragmentModule;

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/example_3/parent_fragment/view/Example3ParentFragmentModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/example_3/parent_fragment/view/Example3ParentFragmentModule.java
@@ -16,7 +16,7 @@
 
 package com.vestrel00.daggerbutterknifemvp.ui.example_3.parent_fragment.view;
 
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 
 import com.vestrel00.daggerbutterknifemvp.inject.PerChildFragment;
 import com.vestrel00.daggerbutterknifemvp.inject.PerFragment;

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/MainActivityModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/MainActivityModule.java
@@ -16,7 +16,7 @@
 
 package com.vestrel00.daggerbutterknifemvp.ui.main;
 
-import android.app.Activity;
+import android.support.v7.app.AppCompatActivity;
 
 import com.vestrel00.daggerbutterknifemvp.inject.PerActivity;
 import com.vestrel00.daggerbutterknifemvp.inject.PerFragment;
@@ -45,7 +45,7 @@ public abstract class MainActivityModule {
 
     /**
      * As per the contract specified in {@link BaseActivityModule}; "This must be included in all
-     * activity modules, which must rovide a concrete implementation of {@link Activity}."
+     * activity modules, which must rovide a concrete implementation of {@link AppCompatActivity}."
      * <p>
      * This provides the activity required to inject the
      * {@link BaseActivityModule#ACTIVITY_FRAGMENT_MANAGER} into the
@@ -56,7 +56,7 @@ public abstract class MainActivityModule {
      */
     @Binds
     @PerActivity
-    abstract Activity activity(MainActivity mainActivity);
+    abstract AppCompatActivity appCompatActivity(MainActivity mainActivity);
 
     /**
      * The main activity listens to the events in the {@link MainFragment}.

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/view/MainFragmentModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/view/MainFragmentModule.java
@@ -16,7 +16,7 @@
 
 package com.vestrel00.daggerbutterknifemvp.ui.main.view;
 
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 
 import com.vestrel00.daggerbutterknifemvp.inject.PerFragment;
 import com.vestrel00.daggerbutterknifemvp.ui.common.view.BaseFragmentModule;

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/util/PerChildFragmentUtil.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/util/PerChildFragmentUtil.java
@@ -16,7 +16,7 @@
 
 package com.vestrel00.daggerbutterknifemvp.util;
 
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 
 import com.vestrel00.daggerbutterknifemvp.inject.PerChildFragment;
 import com.vestrel00.daggerbutterknifemvp.ui.common.view.BaseChildFragmentModule;

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/util/PerFragmentUtil.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/util/PerFragmentUtil.java
@@ -16,7 +16,7 @@
 
 package com.vestrel00.daggerbutterknifemvp.util;
 
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 
 import com.vestrel00.daggerbutterknifemvp.inject.PerFragment;
 import com.vestrel00.daggerbutterknifemvp.ui.common.view.BaseFragmentModule;

--- a/build.gradle
+++ b/build.gradle
@@ -30,5 +30,9 @@ allprojects {
     repositories {
         jcenter()
         mavenCentral()
+        // Required for dagger.android.support
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }


### PR DESCRIPTION
This answers #48.

This feature branch will get merged into the **master-support** branch- not the **master** branch. I will be keeping the non-support and support setups separate to keep things as clean as possible.

The changes are as follows: 

1. Added google maven repository
2. Added *android.dagger.support* to dependencies
3. Set minSdkVersion from `17` to `14`
4. Set Application theme to `Theme.AppCompat`
5. Including `AndroidSupportInjectionModule` instead of `AndroidInjectionModule` in AppModule includes
6. `BaseActivity` and module now using `AppCompatActivity`
7. `BaseFragment` and module now using  `android.app.Fragment`
8. `BaseFragment` now injecting with `AndroidSupportInjection.inject(this)` in only `onAttach(Context)`
9. Replaced all occurrences of `HasFragmentInjector` with `HasSupportFragmentInjector`
10. Replaced all occurrences of `android.app.Fragment` with `android.support.v4.app.Fragment`
11. Replaced all occurrences of `android.app.FragmentManager` with `android.support.v4.app.FragmentManager`