### PR TITLE
Why do you inject FragmentManager into BaseActivity and FragmentManager and Context into BaseFragment? Closes #51

### DIFF
--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/BaseActivity.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/BaseActivity.java
@@ -46,6 +46,12 @@ public abstract class BaseActivity extends Activity implements HasFragmentInject
     @Inject
     protected Navigator navigator;
 
+    /**
+     * A reference to the FragmentManager is injected and used instead of the getter method. This
+     * enables ease of mocking and verification in tests (in case Fragment needs testing).
+     *
+     * For more details, see https://github.com/vestrel00/android-dagger-butterknife-mvp/pull/52
+     */
     @Inject
     @Named(BaseActivityModule.ACTIVITY_FRAGMENT_MANAGER)
     protected FragmentManager fragmentManager;

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/BaseFragment.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/BaseFragment.java
@@ -49,9 +49,25 @@ import dagger.android.HasFragmentInjector;
  */
 public abstract class BaseFragment extends Fragment implements HasFragmentInjector {
 
+    /**
+     * A reference to the activity Context is injected and used instead of the getter method. This
+     * enables ease of mocking and verification in tests (in case Activity needs testing).
+     * More importantly, the getter method (getContext()) is not available for API level below 23.
+     * We could use getActivity() though since that is available since API 11. However, exposing the
+     * Activity reference is less safe than just exposing the Context since a lot more can be done
+     * with the Activity reference.
+     *
+     * For more details, see https://github.com/vestrel00/android-dagger-butterknife-mvp/pull/52
+     */
     @Inject
     protected Context activityContext;
 
+    /**
+     * A reference to the FragmentManager is injected and used instead of the getter method. This
+     * enables ease of mocking and verification in tests (in case Fragment needs testing).
+     *
+     * For more details, see https://github.com/vestrel00/android-dagger-butterknife-mvp/pull/52
+     */
     // Note that this should not be used within a child fragment.
     @Inject
     @Named(BaseFragmentModule.CHILD_FRAGMENT_MANAGER)


### PR DESCRIPTION
This answers #51. 

The answer, as seen in the Javadocs I've added, relates to mocking and verification in unit tests. In the MVP Passive View adaptation of this project, Activities and Fragments should not contain any logic or enough logic to warrant unit tests. However, there may be some cases that unit testing the Activity / Fragment is worth it or even necessary. In such cases, we want to be able to mock every single dependency of the Activity / Fragment. Thus, references to Context and FragmentManager are injected and used in Activities / Fragments instead of their getter method counterparts (`getContext()`, `getFragmentManager()`, or `getChildFragmentManager()`). This enables [Mockito](http://site.mockito.org/) to easily inject mocked versions of these dependencies (via field injection of `@InjectMocks`) for mocking and verification in unit tests.

Take a look at the following **example**.

```java
public final class MainFragment extends BaseFragment {

    @OnClick(R.id.example_1)
    void onExample1Clicked() {
        // Do some work here
        childFragmentManager.executePendingTransactions();
    }
}

public class MainFragmentTest {

    @InjectMocks
    MainFragment testSubject;

    @Mock
    FragmentManager childFragmentManager;

    @Before
    public void setUp() throws Exception {
        MockitoAnnotations.initMocks(this);
    }

    @Test
    public void onExample1Clicked_executesChildFragmentPendingTransactions() throws Exception {
        // WHEN
        testSubject.onExample1Clicked();

        // THEN
        verify(childFragmentManager).executePendingTransactions();
    }
}
```

The above would be all we need in order to mock and verify the `childFragmentManager`. The same pattern would be applied to mock and verify `fragmentManager` in `BaseActivity` and `activityContext` in `BaseFragment`. 

If we were to use the getter method `getChildFragmentManager()`, we would run into a whole lot of pain as explained in case 3 below. All 3 cases described below share the same underlying answer, "to enable ease of mocking and verification in tests".

1. **Why is `FragmentManager` injected into `BaseActivity`? Why not just use `getFragmentManager()` method?**

    To enable ease of mocking and verification in tests. There are several other ways to mock `getFragmentManager()`. 

    - Use `Mockito.spy` to spy on the `testSubject` and have the `getFragmentManager()` method return a mocked `FragmentManager`. However, this method requires the use of [Robolectric](http://robolectric.org/). Without Robolectric, you would get an error: `java.lang.RuntimeException: Method getFragmentManager in android.app.Activity not mocked`. Do note that running tests with RobolectricTestRunner is much slower than just plain JUnit.
    - Create a test class that extends the test subject class and override the `getFragmentManager()` method to return a mock. 

    None of these alternate solutions can compare to the conciseness and simplicity of the injection pattern.

2. **Why is activity `Context` injected into `BaseFragment`? Why not just use `getContext()` method?**

    To enable ease of mocking and verification in tests. More importantly, the getter method [`getContext()`](https://developer.android.com/reference/android/app/Fragment.html#getContext()) is not available for API level below 23. We could use [`getActivity()`](https://developer.android.com/reference/android/app/Fragment.html#getActivity()) though since that is available since API 11. However, exposing the Activity reference is less safe than just exposing the Context since a lot more can be done with the Activity reference.

    In order to mock `getActivity()` method, we could use `Mockito.spy` to spy on the `testSubject` and have the `getActivity()` method return a mocked `Activity`. However, this method requires the use of Robolectric. Without Robolectric, you would get an error: `java.lang.RuntimeException: Method getActivity in android.app.Fragment not mocked`. Do note that running tests with RobolectricTestRunner is much slower than just plain JUnit. We cannot create a test class that extends the test subject class and override the `getActivity()` because it is a final method.

3. **Why is child `FragmentManager` injected into `BaseFragment`? Why not just use `getChildFragmentManager()` method?**

    To enable ease of mocking and verification in tests.

     Mocking the `getChildFragmentManager()` method is similar to mocking the `getActivity()` method but a little bit more involved. You would have to use Robolectric and set the Config sdk to 17 for the test to work since `getChildFragmentManager()` is only available since API 17 and Robolectric by default is compiled against API 16. Even then, you would run into issues where the actual methods of the `childFragmentManager` are being called even when it is mocked. It's just a complicated mess!

Another advantage of injecting these references over using their getter methods is that it promotes uniform access to `Context` and `FragmentManager`. Some non-Activity and non-Fragment classes may need to use `Context` and `FragmentManager` references. This way, the Activity and Fragment classes access `Context` and `FragmentManager` in the same way the non-Activity and non-Fragments do. Following convention / style promotes code readability and understandability throughout the entire project. It allows developers to become familiar with the entire project just by looking at a small portion instead of having to look at the whole.