### PR TITLE
Upgraded Butterknife from 8.7 to 8.8. Closes #57

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ about how to build Android applications using
 [Dagger 2](https://github.com/google/dagger) (2.11/2.12/2.13) with the 
 [Dagger Android extension](https://github.com/google/dagger/tree/master/java/dagger/android), 
 [Dagger Android support extension](https://github.com/google/dagger/tree/master/java/dagger/android/support), 
-[Butterknife](https://github.com/JakeWharton/butterknife), and Model-View-Presenter (MVP) pattern 
+[Butterknife](https://github.com/JakeWharton/butterknife) (8.7/8.8), and Model-View-Presenter (MVP) pattern 
 with support for `@Singleton`, `@PerActivity`, `@PerFragment`, and `@PerChildFragment` scopes.
 
 **A Larger Project**
@@ -14,7 +14,7 @@ with support for `@Singleton`, `@PerActivity`, `@PerFragment`, and `@PerChildFra
 > This project is a smaller, derivative of a larger project. One of the main purpose of this project 
 is to showcase / walkthrough a specific portion of the larger project's architecture. Take a look at
 the following larger project for a more real-world example on how to apply Dagger Android (2.11/2.12/2.13), 
-Butterknife (8.7), Clean Architecture, MVP, MVVM, Kotlin, Java Swing, RxJava, RxAndroid, Retrofit 2, 
+Butterknife (8.7/8.8), Clean Architecture, MVP, MVVM, Kotlin, Java Swing, RxJava, RxAndroid, Retrofit 2, 
 Jackson, AutoValue, Yelp Fusion (v3) REST API, Google Maps API, monolithic repo project management 
 with Gradle, JUNit 4, AssertJ, Mockito 2, Robolectric 3, Espresso 2, and Java best practices and
 design patterns.
@@ -26,7 +26,7 @@ design patterns.
 This project works with the following Dagger 2 and Butterknife versions;
 
 - Dagger 2: *2.11, 2.12, 2.13*
-- Butterknife: *8.7*
+- Butterknife: *8.7, 8.8*
 
 ## Branches
 
@@ -72,7 +72,7 @@ Read the blogs for a complete walkthrough of this app:
 1. Creating a project, from scratch, using the new Dagger.Android (2.11//2.12/2.13) dependency injection 
    framework with support for `@Singleton`, `@PerActivity` , `@PerFragment`, and `@PerChildFragment` scopes. 
    [ARTICLE](https://proandroiddev.com/how-to-android-dagger-2-10-2-11-butterknife-mvp-part-1-eb0f6b970fd)
-2. Using Butterknife (8.7) to replace a lot of handwritten boilerplate view binding code. 
+2. Using Butterknife (8.7/8.8) to replace a lot of handwritten boilerplate view binding code. 
    [ARTICLE](https://proandroiddev.com/how-to-android-dagger-2-10-2-11-butterknife-mvp-part-2-6eaf60965df7)
 3. Restructuring the code to Model-View-Presenter (MVP) to increase testability, maintainability, 
    and scalability.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     // There is a better way to declare and structure dependencies.
     // However, that is a different topic.
     def daggerVersion = '2.13'
-    def butterKnifeVersion = '8.7.0'
+    def butterKnifeVersion = '8.8.0'
 
     annotationProcessor "com.google.dagger:dagger-compiler:$daggerVersion"
     annotationProcessor "com.google.dagger:dagger-android-processor:$daggerVersion"


### PR DESCRIPTION
Upgrades this project's Butterknife version from [8.7](https://github.com/JakeWharton/butterknife/tree/8.7.0) to [8.8](https://github.com/JakeWharton/butterknife/tree/8.8.0). 

The [release notes for 8.8](https://github.com/JakeWharton/butterknife/blob/8.8.0/CHANGELOG.md#version-880-2017-08-04) seem to indicate that this project should still work with no code changes.

- [X] 1. This project's [**master** branch](https://github.com/vestrel00/android-dagger-butterknife-mvp/tree/master) should still work with [Butterknife 8.8](https://github.com/JakeWharton/butterknife/tree/8.8.0).
- [X] 2. This project's [**master-support** branch](https://github.com/vestrel00/android-dagger-butterknife-mvp/tree/master-support) should still work with [Butterknife 8.8](https://github.com/JakeWharton/butterknife/tree/8.8.0).