### PR TITLE
How to inject DialogFragments? Closes #63

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ No. The *dagger.android.support* API only supports `minSdkVersion`
 
 This demonstrates dagger.android, Butterknife, and MVP setup using 3 examples:
 
-1. Activity with 1 fragment.
-2. Activity with 2 fragments.
-3. Activity with 1 fragment with 1 child fragment.
+1. Activity with 1 Fragment.
+2. Activity with 2 Fragments.
+3. Activity with 1 Fragment with 1 child Fragment.
+4. The Fragment in example 1 as a floating dialog.
+5. The Fragments in example 3 as a floating dialog.
 
 ## Walkthrough
 

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/BaseActivity.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/BaseActivity.java
@@ -17,6 +17,7 @@
 package com.vestrel00.daggerbutterknifemvp.ui.common;
 
 import android.app.Activity;
+import android.app.DialogFragment;
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.os.Bundle;
@@ -54,7 +55,7 @@ public abstract class BaseActivity extends Activity implements HasFragmentInject
      */
     @Inject
     @Named(BaseActivityModule.ACTIVITY_FRAGMENT_MANAGER)
-    protected FragmentManager fragmentManager;
+    FragmentManager fragmentManager;
 
     @Inject
     DispatchingAndroidInjector<Fragment> fragmentInjector;
@@ -74,5 +75,9 @@ public abstract class BaseActivity extends Activity implements HasFragmentInject
         fragmentManager.beginTransaction()
                 .add(containerViewId, fragment)
                 .commit();
+    }
+
+    protected final void showDialogFragment(DialogFragment dialogFragment, String tag) {
+        dialogFragment.show(fragmentManager, tag);
     }
 }

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/BaseFragment.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/common/view/BaseFragment.java
@@ -17,6 +17,7 @@
 package com.vestrel00.daggerbutterknifemvp.ui.common.view;
 
 import android.app.Activity;
+import android.app.DialogFragment;
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.content.Context;
@@ -36,8 +37,18 @@ import dagger.android.DispatchingAndroidInjector;
 import dagger.android.HasFragmentInjector;
 
 /**
- * Abstract Fragment for all Fragments and child Fragments to extend. This contains some boilerplate
- * dependency injection code and activity {@link Context}.
+ * Abstract (Dialog)Fragment for all (Dialog)Fragments and child (Dialog)Fragments to extend. This contains some
+ * boilerplate dependency injection code and activity {@link Context}.
+ * <p>
+ * <b>WHY EXTEND DialogFragment?</b>
+ * {@link DialogFragment}s are simple extensions of Fragments. DialogFragments can be shown as a dialog floating above
+ * the current activity or be embedded into views like regular fragments. Therefore, supporting both Fragments and
+ * DialogFragments for dependency injection can simply be achieved by having the base fragment class (this) extend
+ * DialogFragment instead of Fragment. We could have separate base classes for Fragments and DialogFragments but that
+ * would produce duplicate code.
+ * <p>
+ * Note that as of Dagger 2.12, the abstract base framework type {@link dagger.android.DaggerDialogFragment} has been
+ * introduced for subclassing if so desired.
  * <p>
  * <b>DEPENDENCY INJECTION</b>
  * We could extend {@link dagger.android.DaggerFragment} so we can get the boilerplate
@@ -47,7 +58,7 @@ import dagger.android.HasFragmentInjector;
  * <b>VIEW BINDING</b>
  * This fragment handles view bind and unbinding.
  */
-public abstract class BaseFragment extends Fragment implements HasFragmentInjector {
+public abstract class BaseFragment extends DialogFragment implements HasFragmentInjector {
 
     /**
      * A reference to the activity Context is injected and used instead of the getter method. This
@@ -56,7 +67,7 @@ public abstract class BaseFragment extends Fragment implements HasFragmentInject
      * We could use getActivity() though since that is available since API 11. However, exposing the
      * Activity reference is less safe than just exposing the Context since a lot more can be done
      * with the Activity reference.
-     *
+     * <p>
      * For more details, see https://github.com/vestrel00/android-dagger-butterknife-mvp/pull/52
      */
     @Inject
@@ -65,7 +76,7 @@ public abstract class BaseFragment extends Fragment implements HasFragmentInject
     /**
      * A reference to the FragmentManager is injected and used instead of the getter method. This
      * enables ease of mocking and verification in tests (in case Fragment needs testing).
-     *
+     * <p>
      * For more details, see https://github.com/vestrel00/android-dagger-butterknife-mvp/pull/52
      */
     // Note that this should not be used within a child fragment.

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/MainActivity.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/MainActivity.java
@@ -21,6 +21,8 @@ import android.support.annotation.Nullable;
 
 import com.vestrel00.daggerbutterknifemvp.R;
 import com.vestrel00.daggerbutterknifemvp.ui.common.BaseActivity;
+import com.vestrel00.daggerbutterknifemvp.ui.example_1.fragment.view.Example1Fragment;
+import com.vestrel00.daggerbutterknifemvp.ui.example_3.parent_fragment.view.Example3ParentFragment;
 import com.vestrel00.daggerbutterknifemvp.ui.main.view.MainFragment;
 import com.vestrel00.daggerbutterknifemvp.ui.main.view.MainFragmentListener;
 
@@ -28,6 +30,9 @@ import com.vestrel00.daggerbutterknifemvp.ui.main.view.MainFragmentListener;
  * The main activity that provides a way to navigate to all other activities.
  */
 public final class MainActivity extends BaseActivity implements MainFragmentListener {
+
+    private static final String TAG_EXAMPLE_4 = "MainActivity.example_4";
+    private static final String TAG_EXAMPLE_5 = "MainActivity.example_5";
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -52,5 +57,15 @@ public final class MainActivity extends BaseActivity implements MainFragmentList
     @Override
     public void onExample3Clicked() {
         navigator.toExample3(this);
+    }
+
+    @Override
+    public void onExample4Clicked() {
+        showDialogFragment(new Example1Fragment(), TAG_EXAMPLE_4);
+    }
+
+    @Override
+    public void onExample5Clicked() {
+        showDialogFragment(new Example3ParentFragment(), TAG_EXAMPLE_5);
     }
 }

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/MainActivityModule.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/MainActivityModule.java
@@ -21,6 +21,10 @@ import android.app.Activity;
 import com.vestrel00.daggerbutterknifemvp.inject.PerActivity;
 import com.vestrel00.daggerbutterknifemvp.inject.PerFragment;
 import com.vestrel00.daggerbutterknifemvp.ui.common.BaseActivityModule;
+import com.vestrel00.daggerbutterknifemvp.ui.example_1.fragment.view.Example1Fragment;
+import com.vestrel00.daggerbutterknifemvp.ui.example_1.fragment.view.Example1FragmentModule;
+import com.vestrel00.daggerbutterknifemvp.ui.example_3.parent_fragment.view.Example3ParentFragment;
+import com.vestrel00.daggerbutterknifemvp.ui.example_3.parent_fragment.view.Example3ParentFragmentModule;
 import com.vestrel00.daggerbutterknifemvp.ui.main.view.MainFragment;
 import com.vestrel00.daggerbutterknifemvp.ui.main.view.MainFragmentListener;
 import com.vestrel00.daggerbutterknifemvp.ui.main.view.MainFragmentModule;
@@ -42,6 +46,26 @@ public abstract class MainActivityModule {
     @PerFragment
     @ContributesAndroidInjector(modules = MainFragmentModule.class)
     abstract MainFragment mainFragmentInjector();
+
+    /**
+     * Provides the injector for the {@link Example1Fragment}, which has access to the dependencies
+     * provided by this activity and application instance (singleton scoped objects).
+     *
+     * This is used for example 4, which displays {@link Example1Fragment} as a {@link android.app.DialogFragment}.
+     */
+    @PerFragment
+    @ContributesAndroidInjector(modules = Example1FragmentModule.class)
+    abstract Example1Fragment example1FragmentInjector();
+
+    /**
+     * Provides the injector for the {@link Example3ParentFragment}, which has access to the dependencies
+     * provided by this activity and application instance (singleton scoped objects).
+     *
+     * This is used for example 5, which displays {@link Example3ParentFragment} as a {@link android.app.DialogFragment}.
+     */
+    @PerFragment
+    @ContributesAndroidInjector(modules = Example3ParentFragmentModule.class)
+    abstract Example3ParentFragment example3ParentFragmentInjector();
 
     /**
      * As per the contract specified in {@link BaseActivityModule}; "This must be included in all

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/view/MainFragment.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/view/MainFragment.java
@@ -72,4 +72,14 @@ public final class MainFragment extends BaseFragment {
     void onExample3Clicked() {
         listener.onExample3Clicked();
     }
+
+    @OnClick(R.id.example_4)
+    void onExample4Clicked() {
+        listener.onExample4Clicked();
+    }
+
+    @OnClick(R.id.example_5)
+    void onExample5Clicked() {
+        listener.onExample5Clicked();
+    }
 }

--- a/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/view/MainFragmentListener.java
+++ b/app/src/main/java/com/vestrel00/daggerbutterknifemvp/ui/main/view/MainFragmentListener.java
@@ -26,4 +26,8 @@ public interface MainFragmentListener {
     void onExample2Clicked();
 
     void onExample3Clicked();
+
+    void onExample4Clicked();
+
+    void onExample5Clicked();
 }

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -41,5 +41,16 @@
             android:layout_height="wrap_content"
             android:text="@string/example_3" />
 
+        <Button
+            android:id="@+id/example_4"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/example_4" />
+
+        <Button
+            android:id="@+id/example_5"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/example_5" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,8 @@
     <string name="example_1">Ex1: Activity with 1 Fragment</string>
     <string name="example_2">Ex2: Activity with 2 Fragments</string>
     <string name="example_3">Ex3: Activity with 1 Fragment with 1 child Fragment</string>
+    <string name="example_4">Ex4: Ex1 Fragment as a floating dialog</string>
+    <string name="example_5">Ex5: Ex3 Fragment as a floating dialog</string>
 
     <string name="fragment">Fragment</string>
     <string name="fragment_a">Fragment A</string>


### PR DESCRIPTION
This answers #63. 

[`DialogFragments`](https://developer.android.com/reference/android/app/DialogFragment.html) are just regular Fragments that can also be shown in dialog (or alert dialog) form. As with regular Fragments, DialogFragments can also be embedded in an Activity or Fragment's view. 

![dialog_fragment](https://user-images.githubusercontent.com/4332753/34170450-809adc48-e4b0-11e7-80ee-0e1ed6d31324.png)

Therefore, in order to support injecting `DialogFragments` in this project, it is as simple as changing the superclass of our `BaseFragment` from `Fragment` to `DialogFragment`.

To demonstrate DialogFragments in action, I have added 2 more examples (Ex 4 and Ex 5) that uses existing Fragments and displays them in their dialog form.

- **Ex 4.** Example 1 as a floating dialog.
- **Ex 5.** Example 3 as a floating dialog.

**Side Note**

Dagger 2.12 introduced base framework types for DialogFragments;

1. [DaggerDialogFragment](https://github.com/google/dagger/blob/dagger-2.12/java/dagger/android/DaggerDialogFragment.java)
2. [DaggerAppCompatDialogFragment](https://github.com/google/dagger/blob/dagger-2.12/java/dagger/android/support/DaggerAppCompatDialogFragment.java)
