### PR TITLE
Upgraded Dagger from 2.13 to 2.14. Closes #65

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 This project is part of a 
 [3-part series](https://proandroiddev.com/how-to-android-dagger-2-10-2-11-butterknife-mvp-part-1-eb0f6b970fd) 
 about how to build Android applications using 
-[Dagger 2](https://github.com/google/dagger) (2.11/2.12/2.13) with the 
+[Dagger 2](https://github.com/google/dagger) (2.11/2.12/2.13/2.14) with the 
 [Dagger Android extension](https://github.com/google/dagger/tree/master/java/dagger/android), 
 [Dagger Android support extension](https://github.com/google/dagger/tree/master/java/dagger/android/support), 
 [Butterknife](https://github.com/JakeWharton/butterknife) (8.7/8.8), and Model-View-Presenter (MVP) pattern 
@@ -16,7 +16,7 @@ with support for `@Singleton`, `@PerActivity`, `@PerFragment`, and `@PerChildFra
 
 > This project is a smaller, derivative of a larger project. One of the main purpose of this project 
 is to showcase / walkthrough a specific portion of the larger project's architecture. Take a look at
-the following larger project for a more real-world example on how to apply Dagger Android (2.11/2.12/2.13), 
+the following larger project for a more real-world example on how to apply Dagger Android (2.11/2.12/2.13/2.14), 
 Butterknife (8.7/8.8), Clean Architecture, MVP, MVVM, Kotlin, Java Swing, RxJava, RxAndroid, Retrofit 2, 
 Jackson, AutoValue, Yelp Fusion (v3) REST API, Google Maps API, monolithic repo project management 
 with Gradle, JUNit 4, AssertJ, Mockito 2, Robolectric 3, Espresso 2, and Java best practices and
@@ -28,7 +28,7 @@ design patterns.
 
 This project works with the following Dagger 2 and Butterknife versions;
 
-- Dagger 2: *2.11, 2.12, 2.13*
+- Dagger 2: *2.11, 2.12, 2.13, 2.14*
 - Butterknife: *8.7, 8.8*
 
 ## Branches
@@ -75,7 +75,7 @@ This demonstrates dagger.android, Butterknife, and MVP setup using 3 examples:
 
 Read the blogs for a complete walkthrough of this app:
 
-1. Creating a project, from scratch, using the new Dagger.Android (2.11//2.12/2.13) dependency injection 
+1. Creating a project, from scratch, using the new Dagger.Android (2.11//2.12/2.13/2.14) dependency injection 
    framework with support for `@Singleton`, `@PerActivity` , `@PerFragment`, and `@PerChildFragment` scopes. 
    [ARTICLE](https://proandroiddev.com/how-to-android-dagger-2-10-2-11-butterknife-mvp-part-1-eb0f6b970fd)
 2. Using Butterknife (8.7/8.8) to replace a lot of handwritten boilerplate view binding code. 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ android {
 dependencies {
     // There is a better way to declare and structure dependencies.
     // However, that is a different topic.
-    def daggerVersion = '2.13'
+    def daggerVersion = '2.14'
     def butterKnifeVersion = '8.8.0'
 
     annotationProcessor "com.google.dagger:dagger-compiler:$daggerVersion"


### PR DESCRIPTION
Upgrades this project's Dagger version from [2.13](https://github.com/google/dagger/tree/dagger-2.13) to [2.14](https://github.com/google/dagger/tree/dagger-2.14). 

The [release notes for 2.14](https://github.com/google/dagger/releases/tag/dagger-2.14) seem to indicate that this project should still work with no code changes.

- [x] 1. This project's [**master** branch](https://github.com/vestrel00/android-dagger-butterknife-mvp/tree/master) should still work with [Dagger 2.14](https://github.com/google/dagger/tree/dagger-2.14).
- [x] 2. This project's [**master-support** branch](https://github.com/vestrel00/android-dagger-butterknife-mvp/tree/master-support) should still work with [Dagger 2.14](https://github.com/google/dagger/tree/dagger-2.14).